### PR TITLE
Add status management to PdfPrinter

### DIFF
--- a/src/main/java/iscte/ista/pdf_printer/PdfPrinter.java
+++ b/src/main/java/iscte/ista/pdf_printer/PdfPrinter.java
@@ -3,48 +3,46 @@ package iscte.ista.pdf_printer;
 import jakarta.persistence.*;
 import org.jspecify.annotations.Nullable;
 
-import java.time.LocalDate;
 import java.time.Instant;
+import java.time.LocalDate;
 
 @SuppressWarnings("all")
-
 /**
- * Entidade que representa uma impressora PDF.
- * Armazena informações como nome, data de criação e data de vencimento.
+ * Entidade que representa uma impressora PDF (registo).
+ * Armazena nome, data de criação, data de vencimento e status.
  */
 @Entity
 @Table(name = "pdf_printer")
 public class PdfPrinter {
 
-    /**
-     * Identificador único da impressora PDF.
-     */
+    public enum Status {
+        PENDING, PRINTED, SENT, CANCELED
+    }
+
+    /** Identificador único da impressora PDF. */
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     @Column(name = "pdf_printer_id")
     private Long id;
 
-    /**
-     * Nome da impressora PDF.
-     */
+    /** Nome da impressora PDF. */
     @Column(name = "name", nullable = false, length = 100)
     private String name = "";
 
-    /**
-     * Data e hora de criação do registro.
-     */
+    /** Data e hora de criação do registro. */
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
-    /**
-     * Data de vencimento definida pelo usuário.
-     */
-    @Column(name = "due_date", nullable = true)
+    /** Data de vencimento definida pelo usuário. */
+    @Column(name = "due_date")
     private LocalDate dueDate;
 
-    /**
-     * Construtor protegido para uso do Hibernate.
-     */
+    /** Estado do registo. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private Status status = Status.PENDING;
+
+    /** Construtor protegido para uso do Hibernate. */
     protected PdfPrinter() { }
 
     /**
@@ -57,83 +55,59 @@ public class PdfPrinter {
         setName(name);
         this.createdAt = createdAt;
         this.dueDate = dueDate;
+        this.status = Status.PENDING;
     }
 
-    /**
-     * Retorna o ID da impressora PDF.
-     * @return ID
-     */
-    public @Nullable Long getId() {
-        return id;
+    /** PrePersist para garantir campos base. */
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) createdAt = Instant.now();
+        if (status == null) status = Status.PENDING;
     }
 
-    /**
-     * Retorna o nome da impressora PDF.
-     * @return nome
-     */
-    public String getName() {
-        return name;
-    }
+    /** Retorna o ID da impressora PDF. */
+    public @Nullable Long getId() { return id; }
+
+    /** Retorna o nome da impressora PDF. */
+    public String getName() { return name; }
 
     /**
      * Define o nome da impressora PDF.
      * @param name Nome
-     * @throws IllegalArgumentException se o nome exceder 100 caracteres
      */
     public void setName(String name) {
+        if (name == null) name = "";
         if (name.length() > 100) {
             throw new IllegalArgumentException("Nome excede 100 caracteres");
         }
         this.name = name;
     }
 
-    /**
-     * Retorna a data de criação.
-     * @return data de criação
-     */
-    public Instant getCreatedAt() {
-        return createdAt;
-    }
+    /** Retorna a data de criação. */
+    public Instant getCreatedAt() { return createdAt; }
 
-    /**
-     * Retorna a data de vencimento.
-     * @return data de vencimento
-     */
-    public LocalDate getDueDate() {
-        return dueDate;
-    }
+    /** Retorna a data de vencimento. */
+    public LocalDate getDueDate() { return dueDate; }
 
-    /**
-     * Define a data de vencimento.
-     * @param dueDate Data de vencimento
-     */
-    public void setDueDate(LocalDate dueDate) {
-        this.dueDate = dueDate;
-    }
+    /** Define a data de vencimento. */
+    public void setDueDate(LocalDate dueDate) { this.dueDate = dueDate; }
 
-    /**
-     * Compara se dois objetos PdfPrinter são iguais pelo ID.
-     * @param obj Objeto a comparar
-     * @return true se forem iguais, false caso contrário
-     */
+    /** Retorna o status. */
+    public Status getStatus() { return status; }
+
+    /** Define o status. */
+    public void setStatus(Status status) { this.status = (status == null ? Status.PENDING : status); }
+
+    /** Igualdade por ID. */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !getClass().isAssignableFrom(obj.getClass())) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
+        if (obj == null || !getClass().isAssignableFrom(obj.getClass())) return false;
+        if (obj == this) return true;
         PdfPrinter other = (PdfPrinter) obj;
         return getId() != null && getId().equals(other.getId());
     }
 
-    /**
-     * Retorna o hash code da classe.
-     * @return hash code
-     */
+    /** HashCode por classe (Hibernate-safe). */
     @Override
-    public int hashCode() {
-        return getClass().hashCode();
-    }
+    public int hashCode() { return getClass().hashCode(); }
 }

--- a/src/main/java/iscte/ista/pdf_printer/PdfPrinterRepository.java
+++ b/src/main/java/iscte/ista/pdf_printer/PdfPrinterRepository.java
@@ -7,11 +7,12 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 /**
  * Repositório Spring Data JPA para a entidade {@link PdfPrinter}.
- * Permite operações CRUD e consultas paginadas/especificadas.
+ * Permite operações CRUD, paginação e Specifications.
  */
 interface PdfPrinterRepository extends JpaRepository<PdfPrinter, Long>, JpaSpecificationExecutor<PdfPrinter> {
+
+    /**
+     * Lista "simples" paginada (sem filtros). Mantida por compatibilidade.
+     */
     Slice<PdfPrinter> findAllBy(Pageable pageable);
-    // (novo) — não é necessário. Vamos usar o executor de Specifications diretamente no serviço.
 }
-
-

--- a/src/main/java/iscte/ista/pdf_printer/ui/PdfPrinterView.java
+++ b/src/main/java/iscte/ista/pdf_printer/ui/PdfPrinterView.java
@@ -7,6 +7,7 @@ import iscte.ista.pdf_printer.PdfPrinterService.DueFilter;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridSortOrder;
@@ -15,7 +16,6 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.textfield.TextField;
-import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
@@ -37,44 +37,52 @@ class PdfPrinterListView extends Main {
 
     private final PdfPrinterService pdfPrinterService;
 
+    // Create
     final TextField nameField;
     final DatePicker dueDateField;
+    final ComboBox<PdfPrinter.Status> statusField; // status inicial
     final Button createBtn;
 
-    // NOVO:
+    // Filtros
     final TextField searchField;
     final ComboBox<DueFilter> dueFilterBox;
+    final ComboBox<PdfPrinter.Status> statusFilterBox; // NOVO
     final Span totalLabel;
 
+    // Grid
     final Grid<PdfPrinter> printerGrid;
 
     PdfPrinterListView(PdfPrinterService pdfPrinterService) {
         this.pdfPrinterService = pdfPrinterService;
 
-        // Campo de criação: nome
+        // ---- Create controls
         nameField = new TextField();
         nameField.setPlaceholder("PDF name");
         nameField.setAriaLabel("PDF name");
         nameField.setMaxLength(100);
         nameField.setMinWidth("20em");
 
-        // Campo de criação: due date
         dueDateField = new DatePicker();
         dueDateField.setPlaceholder("Due date");
         dueDateField.setAriaLabel("Due date");
 
-        // Botão criar
+        statusField = new ComboBox<>();
+        statusField.setPlaceholder("Status");
+        statusField.setItems(PdfPrinter.Status.values());
+        statusField.setItemLabelGenerator(this::statusLabel);
+        statusField.setWidth("12em");
+        statusField.setValue(PdfPrinter.Status.PENDING);
+
         createBtn = new Button("Create", event -> createPrinter());
         createBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
 
-        // NOVO: pesquisa por nome
+        // ---- Filters
         searchField = new TextField();
         searchField.setPlaceholder("Search by name…");
         searchField.setClearButtonVisible(true);
         searchField.setWidth("16em");
 
-        // NOVO: filtro de vencimento
-        dueFilterBox = new ComboBox<>("Filter");
+        dueFilterBox = new ComboBox<>("Due filter");
         dueFilterBox.setItems(DueFilter.ALL, DueFilter.NO_DUE_DATE, DueFilter.OVERDUE, DueFilter.DUE_TODAY, DueFilter.UPCOMING);
         dueFilterBox.setItemLabelGenerator(v -> switch (v) {
             case ALL -> "All";
@@ -87,77 +95,81 @@ class PdfPrinterListView extends Main {
         dueFilterBox.setWidth("12em");
         dueFilterBox.setClearButtonVisible(true);
 
-        // Formatação de data
+        statusFilterBox = new ComboBox<>("Status filter");
+        statusFilterBox.setItems(PdfPrinter.Status.values());
+        statusFilterBox.setItemLabelGenerator(this::statusLabel);
+        statusFilterBox.setPlaceholder("Any");
+        statusFilterBox.setClearButtonVisible(true);
+        statusFilterBox.setWidth("12em");
+
+        totalLabel = new Span("Total: 0");
+        totalLabel.addClassNames(LumoUtility.FontWeight.SEMIBOLD);
+
+        // ---- Grid
         var dateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).withLocale(getLocale())
                 .withZone(ZoneId.systemDefault());
         var dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(getLocale());
 
-        // Grid
         printerGrid = new Grid<>();
         printerGrid.setSizeFull();
 
-        // Colunas: nome (ordenável)
         var nameCol = printerGrid.addColumn(PdfPrinter::getName).setHeader("Name").setSortable(true);
 
-        // Coluna: Due Date (ordenável)
         var dueCol = printerGrid.addColumn(printer ->
                 Optional.ofNullable(printer.getDueDate()).map(dateFormatter::format).orElse("Not set")
         ).setHeader("Due Date").setSortable(true);
 
-        // Coluna: Created At (ordenável)
         var createdCol = printerGrid.addColumn(printer -> dateTimeFormatter.format(printer.getCreatedAt()))
                 .setHeader("Created At").setSortable(true);
 
-        // NOVO: Coluna estado (badge)
-        printerGrid.addComponentColumn(this::renderDueBadge).setHeader("Status");
+        // Badge por vencimento
+        printerGrid.addComponentColumn(this::renderDueBadge).setHeader("Due").setAutoWidth(true);
 
-        // NOVO: total
-        totalLabel = new Span("Total: 0");
-        totalLabel.addClassNames(LumoUtility.FontWeight.SEMIBOLD);
+        // Editor de status inline (corrigido para atualizar a instância local)
+        printerGrid.addComponentColumn(this::renderStatusEditor).setHeader("Status").setAutoWidth(true);
 
-        // NOVO: Data Provider (lazy) com fetch+count para pesquisa/filtros/ordenacao/paginacao
+        // Data provider com ambos os filtros
         var dp = new CallbackDataProvider<PdfPrinter, Void>(
                 query -> {
                     var pageable = toSpringPageRequest(query);
                     String q = searchField.getValue();
-                    var filter = Optional.ofNullable(dueFilterBox.getValue()).orElse(DueFilter.ALL);
+                    var dueFilter = Optional.ofNullable(dueFilterBox.getValue()).orElse(DueFilter.ALL);
+                    var statusFilter = statusFilterBox.getValue(); // pode ser null
 
                     return pdfPrinterService
-                            .list(q, filter, pageable)
+                            .list(q, dueFilter, statusFilter, pageable)
                             .stream();
                 },
                 query -> {
                     String q = searchField.getValue();
-                    var filter = Optional.ofNullable(dueFilterBox.getValue()).orElse(DueFilter.ALL);
-                    long count = pdfPrinterService.count(q, filter);
+                    var dueFilter = Optional.ofNullable(dueFilterBox.getValue()).orElse(DueFilter.ALL);
+                    var statusFilter = statusFilterBox.getValue();
+                    long count = pdfPrinterService.count(q, dueFilter, statusFilter);
                     totalLabel.setText("Total: " + count);
                     return (int) Math.min(count, Integer.MAX_VALUE);
                 }
         );
         printerGrid.setDataProvider(dp);
 
-        // Ordenação por defeito (Created At desc)
         printerGrid.sort(GridSortOrder.desc(createdCol).build());
 
-        // Layout
         setSizeFull();
         addClassNames(LumoUtility.BoxSizing.BORDER, LumoUtility.Display.FLEX, LumoUtility.FlexDirection.COLUMN,
                 LumoUtility.Padding.MEDIUM, LumoUtility.Gap.SMALL);
 
-        // Toolbar com novos controlos
         add(new ViewToolbar("PDF Prints",
-                ViewToolbar.group(nameField, dueDateField, createBtn),
-                ViewToolbar.group(searchField, dueFilterBox, totalLabel)
+                ViewToolbar.group(nameField, dueDateField, statusField, createBtn),
+                ViewToolbar.group(searchField, dueFilterBox, statusFilterBox, totalLabel)
         ));
 
         add(printerGrid);
 
-        // Listeners para refrescar quando pesquisa/filtro mudam
+        // Refresh nos filtros/pesquisa
         searchField.addValueChangeListener(e -> printerGrid.getDataProvider().refreshAll());
         dueFilterBox.addValueChangeListener(e -> printerGrid.getDataProvider().refreshAll());
+        statusFilterBox.addValueChangeListener(e -> printerGrid.getDataProvider().refreshAll());
     }
 
-    // Badge de estado (overdue / hoje / ok / sem data)
     private Span renderDueBadge(PdfPrinter p) {
         LocalDate today = LocalDate.now();
         Span badge;
@@ -179,6 +191,43 @@ class PdfPrinterListView extends Main {
         return badge;
     }
 
+    /** Editor de status por linha. Corrigido: atualiza a entidade local + refreshItem. */
+    private ComboBox<PdfPrinter.Status> renderStatusEditor(PdfPrinter p) {
+        ComboBox<PdfPrinter.Status> cb = new ComboBox<>();
+        cb.setItems(PdfPrinter.Status.values());
+        cb.setItemLabelGenerator(this::statusLabel);
+        cb.setValue(p.getStatus());
+        cb.setWidth("12em");
+
+        cb.addValueChangeListener(e -> {
+            var newStatus = e.getValue();
+            if (newStatus == null || p.getId() == null) return;
+            try {
+                pdfPrinterService.updateStatus(p.getId(), newStatus);
+                // Atualiza a instância apresentada no Grid para refletir o novo estado
+                p.setStatus(newStatus);
+                printerGrid.getDataProvider().refreshItem(p);
+                Notification.show("Status updated", 2500, Notification.Position.BOTTOM_END)
+                        .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+            } catch (Exception ex) {
+                // Reverter UI se falhar
+                cb.setValue(p.getStatus());
+                Notification.show("Failed to update status: " + ex.getMessage(), 4000, Notification.Position.BOTTOM_END)
+                        .addThemeVariants(NotificationVariant.LUMO_ERROR);
+            }
+        });
+        return cb;
+    }
+
+    private String statusLabel(PdfPrinter.Status s) {
+        return switch (s) {
+            case PENDING -> "Pending";
+            case PRINTED -> "Printed";
+            case SENT -> "Sent";
+            case CANCELED -> "Canceled";
+        };
+    }
+
     private void createPrinter() {
         if (dueDateField.isEmpty()) {
             Notification.show("Please select a due date.", 3000, Notification.Position.BOTTOM_END)
@@ -186,10 +235,15 @@ class PdfPrinterListView extends Main {
             return;
         }
 
-        pdfPrinterService.createPdfPrinter(nameField.getValue(), dueDateField.getValue());
-        printerGrid.getDataProvider().refreshAll();
+        var status = Optional.ofNullable(statusField.getValue()).orElse(PdfPrinter.Status.PENDING);
+        pdfPrinterService.createPdfPrinter(nameField.getValue(), dueDateField.getValue(), status);
+
+        // Limpar + refresh
         nameField.clear();
         dueDateField.clear();
+        statusField.setValue(PdfPrinter.Status.PENDING);
+        printerGrid.getDataProvider().refreshAll();
+
         Notification.show("PDF added", 3000, Notification.Position.BOTTOM_END)
                 .addThemeVariants(NotificationVariant.LUMO_SUCCESS);
     }


### PR DESCRIPTION
This pull request adds support for tracking and managing the status of PDF printer records throughout the backend and frontend. It introduces a new `Status` field to the `PdfPrinter` entity, updates the service and repository to handle status filtering and updates, and enhances the UI to allow users to set and filter by status, as well as update it inline in the grid.

**Backend changes:**

* Added a `Status` enum field (with values: `PENDING`, `PRINTED`, `SENT`, `CANCELED`) to the `PdfPrinter` entity, including database mapping and default initialization logic. [[1]](diffhunk://#diff-a0dc93105e2689a5a58f87123f847bde6e86577810f46d752e9163d56bbb11ddL6-R45) [[2]](diffhunk://#diff-a0dc93105e2689a5a58f87123f847bde6e86577810f46d752e9163d56bbb11ddR58-R112)
* Updated `PdfPrinterService` to support creating records with a specific status, updating status for existing records, and filtering/searching by status in list and count operations. [[1]](diffhunk://#diff-9976a4a73916694c94822f19ba52370cb5114ee1e2df2cb59f7cc48bbda56315R32-R56) [[2]](diffhunk://#diff-9976a4a73916694c94822f19ba52370cb5114ee1e2df2cb59f7cc48bbda56315R65-R69) [[3]](diffhunk://#diff-9976a4a73916694c94822f19ba52370cb5114ee1e2df2cb59f7cc48bbda56315L63-R93)
* Modified `PdfPrinterRepository` to clarify use of specifications for filtering and maintain compatibility with simple paginated queries.

**Frontend/UI changes:**

* Added controls to set initial status when creating a new PDF printer record, and to filter the grid by status. [[1]](diffhunk://#diff-6fb97fe43ae92fae66d373eb08dc8b8992b224ac7699ba4aa998b84133eda017R40-R85) [[2]](diffhunk://#diff-6fb97fe43ae92fae66d373eb08dc8b8992b224ac7699ba4aa998b84133eda017L90-L160)
* Implemented an inline status editor in the grid, allowing users to update the status of a record directly, with immediate feedback and error handling.

These improvements make it possible to fully manage the lifecycle and state of PDF printer records from both backend and frontend interfaces.